### PR TITLE
Improve some block shapes

### DIFF
--- a/src/main/java/com/terraformersmc/cinderscapes/block/BrambleBerryBushBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/BrambleBerryBushBlock.java
@@ -3,9 +3,7 @@ package com.terraformersmc.cinderscapes.block;
 import com.terraformersmc.cinderscapes.init.CinderscapesItems;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.SweetBerryBushBlock;
+import net.minecraft.block.*;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -20,6 +18,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
@@ -28,6 +27,10 @@ import net.minecraft.world.World;
  * @project Cinderscapes
  */
 public class BrambleBerryBushBlock extends SweetBerryBushBlock {
+    private static final VoxelShape SMALL_SHAPE = Block.createCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 8.0D, 13.0D);
+    private static final VoxelShape MEDIUM_SHAPE = Block.createCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 13.0D, 13.0D);
+    private static final VoxelShape LARGE_SHAPE = Block.createCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 14.0D, 14.0D);
+
     public BrambleBerryBushBlock(Settings settings) {
         super(settings);
     }
@@ -48,6 +51,14 @@ public class BrambleBerryBushBlock extends SweetBerryBushBlock {
                 }
             }
 
+        }
+    }
+
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        if (state.get(AGE) == 0) {
+            return SMALL_SHAPE;
+        } else {
+            return state.get(AGE) < 2 ? MEDIUM_SHAPE : LARGE_SHAPE;
         }
     }
 

--- a/src/main/java/com/terraformersmc/cinderscapes/block/BrambleBerryBushBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/BrambleBerryBushBlock.java
@@ -55,10 +55,13 @@ public class BrambleBerryBushBlock extends SweetBerryBushBlock {
     }
 
     public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
-        if (state.get(AGE) == 0) {
-            return SMALL_SHAPE;
-        } else {
-            return state.get(AGE) < 2 ? MEDIUM_SHAPE : LARGE_SHAPE;
+        switch(state.get(AGE)) {
+            case 0:
+                return SMALL_SHAPE;
+            case 1:
+                return MEDIUM_SHAPE;
+            default:
+                return LARGE_SHAPE;
         }
     }
 

--- a/src/main/java/com/terraformersmc/cinderscapes/block/CinderscapesNetherPlantBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/CinderscapesNetherPlantBlock.java
@@ -29,6 +29,10 @@ public class CinderscapesNetherPlantBlock extends PlantBlock {
         return BlockTags.NYLIUM.contains(floor.getBlock()) || floor.isOf(Blocks.SOUL_SOIL) || floor.isOf(Blocks.NETHERRACK) || super.canPlantOnTop(floor, world, pos);
     }
 
+    public AbstractBlock.OffsetType getOffsetType() {
+        return AbstractBlock.OffsetType.XZ;
+    }
+
     @SuppressWarnings("deprecation")
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {

--- a/src/main/java/com/terraformersmc/cinderscapes/block/CinderscapesNetherPlantBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/CinderscapesNetherPlantBlock.java
@@ -4,6 +4,7 @@ import com.terraformersmc.cinderscapes.util.StateShapeSupplier;
 import net.minecraft.block.*;
 import net.minecraft.tag.BlockTags;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 
@@ -16,7 +17,7 @@ import net.minecraft.world.BlockView;
  * @project Cinderscapes
  */
 public class CinderscapesNetherPlantBlock extends PlantBlock {
-    private static StateShapeSupplier SHAPE_SUPPLIER;
+    protected final StateShapeSupplier SHAPE_SUPPLIER;
 
     public CinderscapesNetherPlantBlock(Settings settings, StateShapeSupplier supplier) {
         super(settings);

--- a/src/main/java/com/terraformersmc/cinderscapes/block/CinderscapesNetherPlantBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/CinderscapesNetherPlantBlock.java
@@ -17,7 +17,7 @@ import net.minecraft.world.BlockView;
  * @project Cinderscapes
  */
 public class CinderscapesNetherPlantBlock extends PlantBlock {
-    protected final StateShapeSupplier SHAPE_SUPPLIER;
+    private final StateShapeSupplier SHAPE_SUPPLIER;
 
     public CinderscapesNetherPlantBlock(Settings settings, StateShapeSupplier supplier) {
         super(settings);

--- a/src/main/java/com/terraformersmc/cinderscapes/block/CinderscapesNetherTallPlantBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/CinderscapesNetherTallPlantBlock.java
@@ -16,7 +16,7 @@ import net.minecraft.world.BlockView;
  * @project Cinderscapes
  */
 public class CinderscapesNetherTallPlantBlock extends TallPlantBlock {
-    private static StateShapeSupplier SHAPE_SUPPLIER;
+    protected final StateShapeSupplier SHAPE_SUPPLIER;
 
     public CinderscapesNetherTallPlantBlock(Settings settings, StateShapeSupplier supplier) {
         super(settings);

--- a/src/main/java/com/terraformersmc/cinderscapes/block/CrystiniumBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/CrystiniumBlock.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.ShapeContext;
+import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
@@ -15,6 +16,7 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
+import javax.annotation.Nullable;
 import java.util.Random;
 
 /**
@@ -28,8 +30,12 @@ public class CrystiniumBlock extends CinderscapesNetherPlantBlock {
 
     @Environment(EnvType.CLIENT)
     public void randomDisplayTick(BlockState state, World world, BlockPos pos, Random random) {
+        Vec3d center = this.getOutlineShape(state, world, pos, ShapeContext.absent()).getBoundingBox().getCenter();
+        double x = (double)pos.getX() + center.x;
+        double z = (double)pos.getZ() + center.z;
+
         if (random.nextFloat() > 0.8) {
-            world.addParticle(ParticleTypes.FIREWORK, pos.getX() + random.nextFloat(), pos.getY() + random.nextFloat(), pos.getZ() + random.nextFloat(), random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05);
+            world.addParticle(ParticleTypes.FIREWORK, x + random.nextFloat() - 0.5f, pos.getY() + random.nextFloat(), z + random.nextFloat() - 0.5f, random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05);
         }
     }
 
@@ -37,6 +43,6 @@ public class CrystiniumBlock extends CinderscapesNetherPlantBlock {
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
         Vec3d modelOffset = state.getModelOffset(world, pos);
-        return SHAPE_SUPPLIER.apply(state).offset(modelOffset.x, modelOffset.y, modelOffset.z);
+        return super.getOutlineShape(state, world, pos, context).offset(modelOffset.x, modelOffset.y, modelOffset.z);
     }
 }

--- a/src/main/java/com/terraformersmc/cinderscapes/block/CrystiniumBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/CrystiniumBlock.java
@@ -7,8 +7,12 @@ import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.ShapeContext;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
 import java.util.Random;
@@ -27,5 +31,12 @@ public class CrystiniumBlock extends CinderscapesNetherPlantBlock {
         if (random.nextFloat() > 0.8) {
             world.addParticle(ParticleTypes.FIREWORK, pos.getX() + random.nextFloat(), pos.getY() + random.nextFloat(), pos.getZ() + random.nextFloat(), random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05);
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        Vec3d modelOffset = state.getModelOffset(world, pos);
+        return SHAPE_SUPPLIER.apply(state).offset(modelOffset.x, modelOffset.y, modelOffset.z);
     }
 }

--- a/src/main/java/com/terraformersmc/cinderscapes/block/GhastlyEctoplasmBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/GhastlyEctoplasmBlock.java
@@ -23,18 +23,16 @@ import net.minecraft.world.WorldView;
  */
 public class GhastlyEctoplasmBlock extends Block {
     public static final EnumProperty<GhastlyEctoplasmBlock.Type> TYPE = EnumProperty.of("type", GhastlyEctoplasmBlock.Type.class);
-    private static StateShapeSupplier SHAPE_SUPPLIER;
 
-    public GhastlyEctoplasmBlock(Settings settings, StateShapeSupplier supplier) {
+    public GhastlyEctoplasmBlock(Settings settings) {
         super(settings);
         setDefaultState(getDefaultState().with(TYPE, Type.BOTTOM));
-        SHAPE_SUPPLIER = supplier;
     }
 
     @SuppressWarnings("deprecation")
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
-        return SHAPE_SUPPLIER.apply(state);
+        return state.get(GhastlyEctoplasmBlock.TYPE) == GhastlyEctoplasmBlock.Type.BOTTOM ? Block.createCuboidShape(3.0D, 2.5D, 3.0D, 13.0D, 16.0D, 13.0D) : Block.createCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 16.0D, 15.0D);
     }
 
     @Deprecated

--- a/src/main/java/com/terraformersmc/cinderscapes/block/GhastlyEctoplasmBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/GhastlyEctoplasmBlock.java
@@ -1,14 +1,18 @@
 package com.terraformersmc.cinderscapes.block;
 
+import com.terraformersmc.cinderscapes.util.StateShapeSupplier;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.ShapeContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.IntProperty;
 import net.minecraft.util.StringIdentifiable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 import net.minecraft.world.WorldView;
@@ -18,12 +22,19 @@ import net.minecraft.world.WorldView;
  * @project Cinderscapes
  */
 public class GhastlyEctoplasmBlock extends Block {
-
     public static final EnumProperty<GhastlyEctoplasmBlock.Type> TYPE = EnumProperty.of("type", GhastlyEctoplasmBlock.Type.class);
+    private static StateShapeSupplier SHAPE_SUPPLIER;
 
-    public GhastlyEctoplasmBlock(Settings settings) {
+    public GhastlyEctoplasmBlock(Settings settings, StateShapeSupplier supplier) {
         super(settings);
         setDefaultState(getDefaultState().with(TYPE, Type.BOTTOM));
+        SHAPE_SUPPLIER = supplier;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        return SHAPE_SUPPLIER.apply(state);
     }
 
     @Deprecated

--- a/src/main/java/com/terraformersmc/cinderscapes/block/PolypiteQuartzBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/PolypiteQuartzBlock.java
@@ -65,9 +65,9 @@ public class PolypiteQuartzBlock extends Block {
     static {
         DIRECTION_TO_SHAPE.put(Direction.DOWN, Block.createCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 4.0D, 14.0D));
         DIRECTION_TO_SHAPE.put(Direction.UP, Block.createCuboidShape(2.0D, 12.0D, 2.0D, 14.0D, 16.0D, 14.0D));
-        DIRECTION_TO_SHAPE.put(Direction.SOUTH, Block.createCuboidShape(0.0D, 4.0D, 5.0D, 16.0D, 12.0D, 16.0D));
-        DIRECTION_TO_SHAPE.put(Direction.NORTH, Block.createCuboidShape(0.0D, 4.0D, 0.0D, 16.0D, 12.0D, 11.0D));
-        DIRECTION_TO_SHAPE.put(Direction.EAST, Block.createCuboidShape(5.0D, 4.0D, 0.0D, 16.0D, 12.0D, 16.0D));
-        DIRECTION_TO_SHAPE.put(Direction.WEST, Block.createCuboidShape(0.0D, 4.0D, 0.0D, 11.0D, 12.0D, 16.0D));
+        DIRECTION_TO_SHAPE.put(Direction.SOUTH, Block.createCuboidShape(3.0D, 5.0D, 6.0D, 13.0D, 13.0D, 16.0D));
+        DIRECTION_TO_SHAPE.put(Direction.NORTH, Block.createCuboidShape(3.0D, 5.0D, 0.0D, 13.0D, 13.0D, 10.0D));
+        DIRECTION_TO_SHAPE.put(Direction.EAST, Block.createCuboidShape(6.0D, 5.0D, 3.0D, 16.0D, 13.0D, 13.0D));
+        DIRECTION_TO_SHAPE.put(Direction.WEST, Block.createCuboidShape(0.0D, 5.0D, 3.0D, 10.0D, 13.0D, 13.0D));
     }
 }

--- a/src/main/java/com/terraformersmc/cinderscapes/block/PyracinthBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/PyracinthBlock.java
@@ -25,9 +25,13 @@ public class PyracinthBlock extends CinderscapesNetherPlantBlock {
 
     @Environment(EnvType.CLIENT)
     public void randomDisplayTick(BlockState state, World world, BlockPos pos, Random random) {
-        world.addParticle(ParticleTypes.SMOKE, pos.getX() + random.nextFloat(), pos.getY() + random.nextFloat(), pos.getZ() + random.nextFloat(), random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05);
+        Vec3d center = this.getOutlineShape(state, world, pos, ShapeContext.absent()).getBoundingBox().getCenter();
+        double x = (double)pos.getX() + center.x;
+        double z = (double)pos.getZ() + center.z;
+
+        world.addParticle(ParticleTypes.SMOKE, x + random.nextFloat() - 0.5f, pos.getY() + random.nextFloat(), z + random.nextFloat() - 0.5f, random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05, random.nextFloat() * 0.1 - 0.05);
         if (random.nextFloat() > 0.6) {
-            world.addParticle(ParticleTypes.FLAME, pos.getX() + 0.4f + random.nextFloat() * 0.2f, pos.getY() + 0.5f, pos.getZ() + 0.4f + random.nextFloat() * 0.2f, 0.0f, 0.05f, 0.0f);
+            world.addParticle(ParticleTypes.FLAME, x - 0.1f + random.nextFloat() * 0.2f, pos.getY() + 0.5f, z - 0.1f + random.nextFloat() * 0.2f, 0.0f, 0.05f, 0.0f);
         }
     }
 
@@ -35,6 +39,6 @@ public class PyracinthBlock extends CinderscapesNetherPlantBlock {
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
         Vec3d modelOffset = state.getModelOffset(world, pos);
-        return SHAPE_SUPPLIER.apply(state).offset(modelOffset.x, modelOffset.y, modelOffset.z);
+        return super.getOutlineShape(state, world, pos, context).offset(modelOffset.x, modelOffset.y, modelOffset.z);
     }
 }

--- a/src/main/java/com/terraformersmc/cinderscapes/block/PyracinthBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/PyracinthBlock.java
@@ -4,11 +4,12 @@ import com.terraformersmc.cinderscapes.util.StateShapeSupplier;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
+import net.minecraft.block.*;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
 import java.util.Random;
@@ -19,7 +20,7 @@ import java.util.Random;
  */
 public class PyracinthBlock extends CinderscapesNetherPlantBlock {
     public PyracinthBlock() {
-        super(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0));
+        super(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(5.0, 0.0, 5.0, 11.0, 16.0, 11.0));
     }
 
     @Environment(EnvType.CLIENT)
@@ -28,5 +29,12 @@ public class PyracinthBlock extends CinderscapesNetherPlantBlock {
         if (random.nextFloat() > 0.6) {
             world.addParticle(ParticleTypes.FLAME, pos.getX() + 0.4f + random.nextFloat() * 0.2f, pos.getY() + 0.5f, pos.getZ() + 0.4f + random.nextFloat() * 0.2f, 0.0f, 0.05f, 0.0f);
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        Vec3d vec3d = state.getModelOffset(world, pos);
+        return SHAPE_SUPPLIER.apply(state).offset(vec3d.x, vec3d.y, vec3d.z);
     }
 }

--- a/src/main/java/com/terraformersmc/cinderscapes/block/PyracinthBlock.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/block/PyracinthBlock.java
@@ -34,7 +34,7 @@ public class PyracinthBlock extends CinderscapesNetherPlantBlock {
     @SuppressWarnings("deprecation")
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
-        Vec3d vec3d = state.getModelOffset(world, pos);
-        return SHAPE_SUPPLIER.apply(state).offset(vec3d.x, vec3d.y, vec3d.z);
+        Vec3d modelOffset = state.getModelOffset(world, pos);
+        return SHAPE_SUPPLIER.apply(state).offset(modelOffset.x, modelOffset.y, modelOffset.z);
     }
 }

--- a/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
@@ -57,7 +57,7 @@ public class CinderscapesBlocks {
     public static final Block ASH = add("ash", new AshLayerBlock(FabricBlockSettings.copyOf(Blocks.SNOW).breakByTool(FabricToolTags.SHOVELS)), ItemGroup.DECORATIONS);
     public static final Block ASH_BLOCK = add("ash_block", new Block(FabricBlockSettings.copyOf(Blocks.SNOW_BLOCK).breakByTool(FabricToolTags.SHOVELS)), ItemGroup.DECORATIONS);
 
-    public static Block PYRACINTH = add("pyracinth", new PyracinthBlock(), ItemGroup.DECORATIONS);
+    public static final Block PYRACINTH = add("pyracinth", new PyracinthBlock(), ItemGroup.DECORATIONS);
 
     ////////////////////
     // Luminous Grove //
@@ -73,8 +73,8 @@ public class CinderscapesBlocks {
 
     public static final Block UMBRAL_NYLIUM = add("umbral_nylium", new CinderscapesNyliumBlock(FabricBlockSettings.copyOf(Blocks.WARPED_NYLIUM).materialColor(MaterialColor.BLUE).breakByTool(FabricToolTags.PICKAXES)), ItemGroup.BUILDING_BLOCKS);
     public static final Block UMBRAL_FUNGUS = add("umbral_fungus", new CinderscapesCanopiedFungusBlock(FabricBlockSettings.copyOf(Blocks.WARPED_FUNGUS).materialColor(MaterialColor.BLUE).breakByTool(FabricToolTags.PICKAXES).lightLevel(15), () -> CinderscapesFeatures.CANOPIED_HUGE_FUNGUS.configure(CinderscapesFeatures.UMBRAL_FUNGUS_CONFIG)), ItemGroup.DECORATIONS);
-    public static Block UMBRAL_WART_BLOCK = add("umbral_wart_block", new CinderscapesTransparentBlock(FabricBlockSettings.copyOf(Blocks.WARPED_WART_BLOCK).materialColor(MaterialColor.BLUE).breakByTool(FabricToolTags.HOES).nonOpaque()), ItemGroup.BUILDING_BLOCKS);
-    public static Block UMBRAL_FLESH_BLOCK = add("umbral_flesh_block", new Block(FabricBlockSettings.copyOf(UMBRAL_WART_BLOCK).breakByTool(FabricToolTags.HOES).lightLevel(15)), ItemGroup.BUILDING_BLOCKS);
+    public static final Block UMBRAL_WART_BLOCK = add("umbral_wart_block", new CinderscapesTransparentBlock(FabricBlockSettings.copyOf(Blocks.WARPED_WART_BLOCK).materialColor(MaterialColor.BLUE).breakByTool(FabricToolTags.HOES).nonOpaque()), ItemGroup.BUILDING_BLOCKS);
+    public static final Block UMBRAL_FLESH_BLOCK = add("umbral_flesh_block", new Block(FabricBlockSettings.copyOf(UMBRAL_WART_BLOCK).breakByTool(FabricToolTags.HOES).lightLevel(15)), ItemGroup.BUILDING_BLOCKS);
 
     public static final Block UMBRAL_PLANKS = add("umbral_planks", new Block(FabricBlockSettings.copyOf(Blocks.WARPED_PLANKS).materialColor(MaterialColor.BLUE)), ItemGroup.BUILDING_BLOCKS);
     public static final Block UMBRAL_SLAB = add("umbral_slab", new SlabBlock(FabricBlockSettings.copyOf(Blocks.WARPED_SLAB).materialColor(MaterialColor.BLUE)), ItemGroup.BUILDING_BLOCKS);
@@ -90,14 +90,14 @@ public class CinderscapesBlocks {
 
     // Other
 
-    public static Block TWILIGHT_VINE_BLOCK = add("twilight_vine_block", new Block(FabricBlockSettings.of(Material.SOLID_ORGANIC).strength(1.0F).sounds(BlockSoundGroup.NETHER_STEM)), ItemGroup.DECORATIONS);
+    public static final Block TWILIGHT_VINE_BLOCK = add("twilight_vine_block", new Block(FabricBlockSettings.of(Material.SOLID_ORGANIC).strength(1.0F).sounds(BlockSoundGroup.NETHER_STEM)), ItemGroup.DECORATIONS);
 
-    public static Block TWILIGHT_TENDRILS = add("twilight_tendrils", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS).lightLevel((state) -> 15), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
-    public static Block TWILIGHT_FESCUES = add("twilight_fescues", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
-    public static Block PHOTOFERN = add("photofern", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
-    public static Block TALL_PHOTOFERN = add("tall_photofern", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);
-    public static Block LUMINOUS_POD = add("luminous_pod", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS).lightLevel((state) -> 15), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);
-    public static Block GHASTLY_ECTOPLASM = add("ghastly_ectoplasm", new GhastlyEctoplasmBlock(FabricBlockSettings.of(Material.ORGANIC_PRODUCT).noCollision().breakInstantly().sounds(BlockSoundGroup.ROOTS)), ItemGroup.DECORATIONS);
+    public static final Block TWILIGHT_TENDRILS = add("twilight_tendrils", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS).lightLevel((state) -> 15), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
+    public static final Block TWILIGHT_FESCUES = add("twilight_fescues", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 4.0, 14.0)), ItemGroup.DECORATIONS);
+    public static final Block PHOTOFERN = add("photofern", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(4.0, 0.0, 4.0, 12.0, 13.0, 12.0)), ItemGroup.DECORATIONS);
+    public static final Block TALL_PHOTOFERN = add("tall_photofern", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);
+    public static final Block LUMINOUS_POD = add("luminous_pod", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS).lightLevel((state) -> 15), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);
+    public static final Block GHASTLY_ECTOPLASM = add("ghastly_ectoplasm", new GhastlyEctoplasmBlock(FabricBlockSettings.of(Material.ORGANIC_PRODUCT).noCollision().breakInstantly().sounds(BlockSoundGroup.ROOTS)), ItemGroup.DECORATIONS);
 
     ///////////
     // Other //
@@ -112,7 +112,7 @@ public class CinderscapesBlocks {
     // Quartz Canyon //
     ///////////////////
 
-    public static Block CRYSTINIUM = add("crystinium", new CrystiniumBlock(), ItemGroup.DECORATIONS);
+    public static final Block CRYSTINIUM = add("crystinium", new CrystiniumBlock(), ItemGroup.DECORATIONS);
 
     public static final Block CRYSTALLINE_QUARTZ = add("crystalline_quartz", new CinderscapesTransparentBlock(FabricBlockSettings.copyOf(Blocks.QUARTZ_BLOCK).sounds(BlockSoundGroup.GLASS).nonOpaque().allowsSpawning(CinderscapesBlocks::never).solidBlock(CinderscapesBlocks::never).suffocates(CinderscapesBlocks::never).blockVision(CinderscapesBlocks::never)), ItemGroup.BUILDING_BLOCKS);
     public static final Block POLYPITE_QUARTZ = add("polypite_quartz", new PolypiteQuartzBlock(FabricBlockSettings.copyOf(CRYSTALLINE_QUARTZ)), ItemGroup.DECORATIONS);

--- a/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
@@ -93,7 +93,7 @@ public class CinderscapesBlocks {
     public static final Block TWILIGHT_VINE_BLOCK = add("twilight_vine_block", new Block(FabricBlockSettings.of(Material.SOLID_ORGANIC).strength(1.0F).sounds(BlockSoundGroup.NETHER_STEM)), ItemGroup.DECORATIONS);
 
     public static final Block TWILIGHT_TENDRILS = add("twilight_tendrils", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS).lightLevel((state) -> 15), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
-    public static final Block TWILIGHT_FESCUES = add("twilight_fescues", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 4.0, 14.0)), ItemGroup.DECORATIONS);
+    public static final Block TWILIGHT_FESCUES = add("twilight_fescues", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 5.0, 14.0)), ItemGroup.DECORATIONS);
     public static final Block PHOTOFERN = add("photofern", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(4.0, 0.0, 4.0, 12.0, 13.0, 12.0)), ItemGroup.DECORATIONS);
     public static final Block TALL_PHOTOFERN = add("tall_photofern", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);
     public static final Block LUMINOUS_POD = add("luminous_pod", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS).lightLevel((state) -> 15), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);

--- a/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
@@ -97,7 +97,7 @@ public class CinderscapesBlocks {
     public static Block PHOTOFERN = add("photofern", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
     public static Block TALL_PHOTOFERN = add("tall_photofern", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);
     public static Block LUMINOUS_POD = add("luminous_pod", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS).lightLevel((state) -> 15), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);
-    public static Block GHASTLY_ECTOPLASM = add("ghastly_ectoplasm", new GhastlyEctoplasmBlock(FabricBlockSettings.of(Material.ORGANIC_PRODUCT).noCollision().breakInstantly().sounds(BlockSoundGroup.ROOTS)), ItemGroup.DECORATIONS);
+    public static Block GHASTLY_ECTOPLASM = add("ghastly_ectoplasm", new GhastlyEctoplasmBlock(FabricBlockSettings.of(Material.ORGANIC_PRODUCT).noCollision().breakInstantly().sounds(BlockSoundGroup.ROOTS), (state) -> state.get(GhastlyEctoplasmBlock.TYPE) == GhastlyEctoplasmBlock.Type.BOTTOM ? Block.createCuboidShape(3.0D, 2.5D, 3.0D, 13.0D, 16.0D, 13.0D) : Block.createCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 16.0D, 15.0D)), ItemGroup.DECORATIONS);
 
     ///////////
     // Other //

--- a/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
@@ -50,8 +50,8 @@ public class CinderscapesBlocks {
     public static final Block SCORCHED_SIGN = add("scorched_sign", new TerraformSignBlock(Cinderscapes.id("entity/signs/scorched"), FabricBlockSettings.copyOf(Blocks.WARPED_SIGN).materialColor(MaterialColor.LIGHT_GRAY)));
     public static final Block SCORCHED_WALL_SIGN = add("scorched_wall_sign", new TerraformWallSignBlock(Cinderscapes.id("entity/signs/scorched"), FabricBlockSettings.copyOf(Blocks.WARPED_WALL_SIGN).materialColor(MaterialColor.LIGHT_GRAY)));
 
-    public static final Block SCORCHED_SHRUB = add("scorched_shrub", new CinderscapesNetherPlantBlock(FabricBlockSettings.copyOf(Blocks.DEAD_BUSH), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
-    public static final Block SCORCHED_SPROUTS = add("scorched_sprouts", new CinderscapesNetherPlantBlock(FabricBlockSettings.copyOf(Blocks.DEAD_BUSH), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
+    public static final Block SCORCHED_SHRUB = add("scorched_shrub", new CinderscapesNetherPlantBlock(FabricBlockSettings.copyOf(Blocks.DEAD_BUSH), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 14.0, 14.0)), ItemGroup.DECORATIONS);
+    public static final Block SCORCHED_SPROUTS = add("scorched_sprouts", new CinderscapesNetherPlantBlock(FabricBlockSettings.copyOf(Blocks.DEAD_BUSH), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 3.0, 14.0)), ItemGroup.DECORATIONS);
     public static final Block SCORCHED_TENDRILS = add("scorched_tendrils", new CinderscapesNetherPlantBlock(FabricBlockSettings.copyOf(Blocks.DEAD_BUSH), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
 
     public static final Block ASH = add("ash", new AshLayerBlock(FabricBlockSettings.copyOf(Blocks.SNOW).breakByTool(FabricToolTags.SHOVELS)), ItemGroup.DECORATIONS);

--- a/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
+++ b/src/main/java/com/terraformersmc/cinderscapes/init/CinderscapesBlocks.java
@@ -97,7 +97,7 @@ public class CinderscapesBlocks {
     public static Block PHOTOFERN = add("photofern", new CinderscapesNetherPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 12.0, 14.0)), ItemGroup.DECORATIONS);
     public static Block TALL_PHOTOFERN = add("tall_photofern", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);
     public static Block LUMINOUS_POD = add("luminous_pod", new CinderscapesNetherTallPlantBlock(FabricBlockSettings.copy(Blocks.WARPED_ROOTS).lightLevel((state) -> 15), (state) -> Block.createCuboidShape(2.0, 0, 2.0, 14.0, 16.0, 14.0)), ItemGroup.DECORATIONS);
-    public static Block GHASTLY_ECTOPLASM = add("ghastly_ectoplasm", new GhastlyEctoplasmBlock(FabricBlockSettings.of(Material.ORGANIC_PRODUCT).noCollision().breakInstantly().sounds(BlockSoundGroup.ROOTS), (state) -> state.get(GhastlyEctoplasmBlock.TYPE) == GhastlyEctoplasmBlock.Type.BOTTOM ? Block.createCuboidShape(3.0D, 2.5D, 3.0D, 13.0D, 16.0D, 13.0D) : Block.createCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 16.0D, 15.0D)), ItemGroup.DECORATIONS);
+    public static Block GHASTLY_ECTOPLASM = add("ghastly_ectoplasm", new GhastlyEctoplasmBlock(FabricBlockSettings.of(Material.ORGANIC_PRODUCT).noCollision().breakInstantly().sounds(BlockSoundGroup.ROOTS)), ItemGroup.DECORATIONS);
 
     ///////////
     // Other //


### PR DESCRIPTION
This PR:
- Adds random nether plant offset integration
- Fixes shape supplier variables getting overwritten for each entry using the same class with these variables
- Modifies shapes for pyracinths, twilight fescues, polypites, twilight fescues, scorched srubs, bramble berry bushes and ghastly ectoplasm