### PR TITLE
Allow crafting stripped hyphae from stripped stems

### DIFF
--- a/src/main/resources/data/cinderscapes/recipes/stripped_scorched_hyphae.json
+++ b/src/main/resources/data/cinderscapes/recipes/stripped_scorched_hyphae.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "cinderscapes:stripped_scorched_stem"
+    }
+  },
+  "result": {
+    "item": "cinderscapes:stripped_scorched_hyphae",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/cinderscapes/recipes/stripped_umbral_hyphae.json
+++ b/src/main/resources/data/cinderscapes/recipes/stripped_umbral_hyphae.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "cinderscapes:stripped_umbral_stem"
+    }
+  },
+  "result": {
+    "item": "cinderscapes:stripped_umbral_hyphae",
+    "count": 3
+  }
+}


### PR DESCRIPTION
This pull request adds recipes for stripped scorched and umbral hyphae to maintain consistency with vanilla, similarly to TerraformersMC/Terrestria#236 and TerraformersMC/Traverse#58.