### PR TITLE
Optimize tickAsh method in MixinServerWorld

### DIFF
--- a/common/src/main/java/com/terraformersmc/cinderscapes/mixin/MixinServerWorld.java
+++ b/common/src/main/java/com/terraformersmc/cinderscapes/mixin/MixinServerWorld.java
@@ -41,7 +41,7 @@ abstract class MixinServerWorld extends World {
         // Ashy shoals only exists in the nether, why do this iteration on any other dimension
         if (!getDimensionEntry().matchesKey(DimensionTypes.THE_NETHER)) return;
         if (CinderscapesConfig.INSTANCE.enableAshFall) {
-            BlockPos pos = tickPos.mutableCopy();
+            BlockPos.Mutable pos = tickPos.mutableCopy();
 
             for (; pos.getY() < 127; pos.setY(pos.getY() + 1)) {
                 BlockPos up = pos.up();

--- a/common/src/main/java/com/terraformersmc/cinderscapes/mixin/MixinServerWorld.java
+++ b/common/src/main/java/com/terraformersmc/cinderscapes/mixin/MixinServerWorld.java
@@ -16,7 +16,9 @@ import net.minecraft.world.MutableWorldProperties;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.dimension.DimensionType;
+import net.minecraft.world.dimension.DimensionTypes;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -25,8 +27,8 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import java.util.function.Supplier;
 
 @Mixin(ServerWorld.class)
-public abstract class MixinServerWorld extends World {
-    protected MixinServerWorld(MutableWorldProperties properties, RegistryKey<World> registryRef, DynamicRegistryManager registryManager, RegistryEntry<DimensionType> dimensionEntry, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long biomeAccess, int maxChainedNeighborUpdates) {
+abstract class MixinServerWorld extends World {
+    private MixinServerWorld(MutableWorldProperties properties, RegistryKey<World> registryRef, DynamicRegistryManager registryManager, RegistryEntry<DimensionType> dimensionEntry, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long biomeAccess, int maxChainedNeighborUpdates) {
         super(properties, registryRef, registryManager, dimensionEntry, profiler, isClient, debugWorld, biomeAccess, maxChainedNeighborUpdates);
     }
 
@@ -36,33 +38,38 @@ public abstract class MixinServerWorld extends World {
      */
     @Inject(method="tickIceAndSnow", at = @At(value = "HEAD"), locals = LocalCapture.NO_CAPTURE)
     private void cinderscapes$tickAsh(BlockPos tickPos, CallbackInfo ci) {
+        // Ashy shoals only exists in the nether, why do this iteration on any other dimension
+        if (!getDimensionEntry().matchesKey(DimensionTypes.THE_NETHER)) return;
         if (CinderscapesConfig.INSTANCE.enableAshFall) {
             BlockPos pos = tickPos.mutableCopy();
-            BlockState state = getBlockState(pos);
-            RegistryEntry<Biome> biome = this.getBiome(pos);
 
-            while (pos.getY() < 127 && !(
-                    biome.matchesKey(CinderscapesBiomes.ASHY_SHOALS) &&
-                    state.isSideSolidFullSquare(this, pos, Direction.UP) &&
-                    blockAbove(pos).isIn(CinderscapesBlockTags.ASH_PERMEABLE) &&
-                    this.getBlockState(pos.up()).isAir() &&
-                    CinderscapesBlocks.ASH.getDefaultState().canPlaceAt(this, pos.up()))) {
-                pos = pos.up();
-                state = getBlockState(pos);
-                biome = this.getBiome(pos);
-            }
-
-            if (pos.getY() < 127) {
-                this.setBlockState(pos.up(), CinderscapesBlocks.ASH.getDefaultState());
+            for (; pos.getY() < 127; pos.setY(pos.getY() + 1)) {
+                BlockPos up = pos.up();
+                if (!canPlace(up)) {
+                    continue;
+                } else if (!this.getBiome(up).matchesKey(CinderscapesBiomes.ASHY_SHOALS)) {
+                    continue;
+                }
+                this.setBlockState(up, CinderscapesBlocks.ASH.getDefaultState());
+                break;
             }
         }
     }
 
-    private BlockState blockAbove(BlockPos pos) {
-        BlockPos iPos = pos.mutableCopy().up();
+    @Unique
+    private boolean canPlace(BlockPos pos){
+        return this.getBlockState(pos).isAir() &&
+                blockAbove(pos).isIn(CinderscapesBlockTags.ASH_PERMEABLE) &&
+                CinderscapesBlocks.ASH.getDefaultState().canPlaceAt(this, pos);
+    }
 
+    @Unique
+    private BlockState blockAbove(BlockPos pos) {
+        BlockPos iPos = pos.mutableCopy();
+
+        //up() makes new immutable blockpos per call. This uses the Mutable as a Mutable.
         //noinspection StatementWithEmptyBody
-        for (; isAir(iPos) && iPos.getY() < 127; iPos = iPos.up());
+        for (; isAir(iPos) && iPos.getY() < 127; iPos.setY(iPos.getY() + 1));
 
         return getBlockState(iPos);
     }


### PR DESCRIPTION
# Fixes:
In server environments, cinderscapes can eat 2-5+ percent of server thread time running it's `tickAsh` method. This PR optimizes that method heavily. Below screenshot is from a 1.20.1 server, but the same method is utilized in 1.20.5, and the same problems are present.
![image](https://github.com/TerraformersMC/Cinderscapes/assets/72876796/2243e4b0-8a30-4f64-9348-88a4ebcf51bc)

# Causes:
- The previous implementation of `tickAsh` runs `getBiome(pos)` potentially dozens of times per randomTick, which is a very expensive operation in high quantities.
- The mixin does not short-circuit if the ServerWorld dimension isn't the Nether, causing (failed) `getBiome` checks in every dimension regardless if the biome exists there at all. Ashy Shoals is only added to the Nether, it should only run in the Nether.
- BlockPos operations don't make use of the faster operations of `BlockPos.Mutable`, instead using `.up()` extensively, which is a method from the Immutable `BlockPos`
- Redundant calls to `pos.up` and `isSideSolidFullSquare`

# Implementation
- Short circuit if the dim isn't the Nether
- Redesigned the check into a for loop. Loop design dispenses with the need for any allocation of `state` or `biome`. 
- Removes redundant check to `isSideSolidFullSquare`, as the `canPlaceAt` check does this already.
- simplified if statement into it's own method.
- Optimized `blockAbove` by using the `Mutable.setY` method to avoid repeated allocation of new BlockPos
- Only check for biomes if every other condition is met.

# Opportunities
- `blockAbove` is a pretty expensive method, as it's iterating to (typically) the same block over and over again while checking every blockstate on the way. Some method to cache the "block above" would be beneficial, only re-utilizing `blockAbove` when the iterator is above the previously cached blockstate
- Since I've already demonstrated decent performance improvements in profiling on my Singleplayer test, this doesn't seem critical

Singleplayer before (1.20.1 build)
![image](https://github.com/TerraformersMC/Cinderscapes/assets/72876796/588bae4b-18ae-490a-9198-828aef5a6098)

Singleplayer after (1.20.1 build)
![image](https://github.com/TerraformersMC/Cinderscapes/assets/72876796/8960a02c-81a3-41f9-8c03-271c340dd62a)
