### PR TITLE
Add cinderscapes ores to the c:ores_in_ground/netherrack block and item tags

### DIFF
--- a/common/src/main/java/com/terraformersmc/cinderscapes/data/CinderscapesBlockTagProvider.java
+++ b/common/src/main/java/com/terraformersmc/cinderscapes/data/CinderscapesBlockTagProvider.java
@@ -218,6 +218,12 @@ public class CinderscapesBlockTagProvider extends FabricTagProvider.BlockTagProv
 		valueLookupBuilder(ConventionalBlockTags.ORES)
 				.add(CinderscapesBlocks.SULFUR_ORE);
 
+		valueLookupBuilder(ConventionalBlockTags.ORES_IN_GROUND_NETHERRACK)
+				.add(CinderscapesBlocks.ROSE_QUARTZ_ORE)
+				.add(CinderscapesBlocks.SMOKY_QUARTZ_ORE)
+				.add(CinderscapesBlocks.SULFUR_QUARTZ_ORE)
+				.add(CinderscapesBlocks.SULFUR_ORE);
+
 		valueLookupBuilder(ConventionalBlockTags.QUARTZ_ORES)
 				.add(CinderscapesBlocks.ROSE_QUARTZ_ORE)
 				.add(CinderscapesBlocks.SMOKY_QUARTZ_ORE)

--- a/common/src/main/java/com/terraformersmc/cinderscapes/data/CinderscapesItemTagProvider.java
+++ b/common/src/main/java/com/terraformersmc/cinderscapes/data/CinderscapesItemTagProvider.java
@@ -140,6 +140,12 @@ public class CinderscapesItemTagProvider extends FabricTagProvider.ItemTagProvid
 				.add(CinderscapesBlocks.SULFUR_QUARTZ_BRICKS.asItem())
 				.add(CinderscapesBlocks.SULFUR_QUARTZ_PILLAR.asItem());
 
+		valueLookupBuilder(ConventionalItemTags.ORES_IN_GROUND_NETHERRACK)
+				.add(CinderscapesBlocks.ROSE_QUARTZ_ORE.asItem())
+				.add(CinderscapesBlocks.SMOKY_QUARTZ_ORE.asItem())
+				.add(CinderscapesBlocks.SULFUR_QUARTZ_ORE.asItem())
+				.add(CinderscapesBlocks.SULFUR_ORE.asItem());
+
 		valueLookupBuilder(ConventionalItemTags.QUARTZ_ORES)
 				.add(CinderscapesBlocks.ROSE_QUARTZ_ORE.asItem())
 				.add(CinderscapesBlocks.SMOKY_QUARTZ_ORE.asItem())


### PR DESCRIPTION
Self explanatory lol, adds the ores from Cinderscapes to the conventional `c:ores_in_ground/netherrack` block and item tags. This should improve mod compatibility for when mods need to check for a generic set of nether ores (the tag already contains nether gold and nether quartz).